### PR TITLE
Fix logger hardcode

### DIFF
--- a/niklib/utils/loggers.py
+++ b/niklib/utils/loggers.py
@@ -201,6 +201,3 @@ class Logger(logging.Logger):
 
         # keep last handler so we can remove it on next call
         self.__prev_handler = logger_handler
-
-kek = Logger('kek', 10, 'kek')
-kek.create_artifact_instance('lel')


### PR DESCRIPTION
Previously, all subdirs as mlflow artifacts in `niklab.utils.loggers.Logger` were hardcoded. Now, it is dynamically created via users desired subdirs.

The reason it was hardcoded was that it was explicitly built for a vision task and all those subdirs were constant all the time. But since `niklib` has to be general, it had to be fixed. (by the way, it was a terrible SWE practice, why even reason for obvious pepeganism).